### PR TITLE
Update QRCode Reader to use navigator.mediaDevices

### DIFF
--- a/public/assets/javascript/check_in.js
+++ b/public/assets/javascript/check_in.js
@@ -129,11 +129,10 @@ var checkinApp = new Vue({
 
             navigator.mediaDevices.getUserMedia({
                 video: {
-                    facingMode: 'environment'
+                    facingMode: "environment" //TODO: Add switch to toggle "user" or "enviroment"
                 },
                 audio: false
-            }, function (stream) {
-
+            }).then(function(stream) {
                 that.stream = stream;
 
                 if (that.videoElement.mozSrcObject !== undefined) { // works on firefox now
@@ -141,8 +140,8 @@ var checkinApp = new Vue({
                 } else if(window.URL) { // and chrome, but must use https
                     that.videoElement.srcObject = stream;
                 };
-
-            }, function () { /* error*/
+            }).catch(function(err) {
+                console.log(err.name + ": " + err.message);
                 alert(lang("checkin_init_error"));
             });
 
@@ -150,7 +149,7 @@ var checkinApp = new Vue({
             this.QrTimeout = setTimeout(function () {
                 that.captureQrToCanvas();
             }, 500);
-
+            
         },
         /**
          * Takes stills from the video stream and sends them to the canvas so


### PR DESCRIPTION
Update to use navigator.mediaDevices for Safari and Chrome Desktop to enable using camera